### PR TITLE
Change to colors makes the card to be used with dark theme

### DIFF
--- a/dist/epg-card.js
+++ b/dist/epg-card.js
@@ -101,9 +101,9 @@ class EPGCard extends HTMLElement {
                  .program {
       position: absolute;
       height: ${row_height}px;
-      background-color: rgb(204, 225, 248);
-      border-color: gray:
-      color: black;
+      background-color: gray;
+      border-color: gray;
+      color: white;
       border-radius: 4px;
       padding: 5px;
       display: flex;


### PR DESCRIPTION
By replacing background color and text color the EPG-card is usable in both themes, light and dark, 

Without this change, only light theme can be used,